### PR TITLE
Subresource integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.10.3](https://github.com/TLenahan/loadable-components/compare/v5.10.2...v5.10.3) (2019-09-10)
+
+
+### Bug Fixes
+
+* support IE 11 without polyfill ([#416](https://github.com/TLenahan/loadable-components/issues/416)) ([80ee809](https://github.com/TLenahan/loadable-components/commit/80ee809)), closes [#397](https://github.com/TLenahan/loadable-components/issues/397)
+
+
+
+
+
 ## [5.10.2](https://github.com/smooth-code/loadable-components/compare/v5.10.1...v5.10.2) (2019-07-15)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.10.2",
+  "version": "5.10.3",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.10.3",
+  "version": "5.10.4",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/babel-plugin/CHANGELOG.md
+++ b/packages/babel-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.10.3](https://github.com/smooth-code/loadable-components/compare/v5.10.2...v5.10.3) (2019-09-10)
+
+**Note:** Version bump only for package @parkwhiz-js/loadable-babel-plugin
+
+
+
+
+
 # [5.10.0](https://github.com/smooth-code/loadable-components/compare/v5.9.0...v5.10.0) (2019-05-13)
 
 

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parkwhiz-js/loadable-babel-plugin",
   "description": "Babel plugin for loadable (required for SSR).",
-  "version": "5.10.0",
+  "version": "5.10.3",
   "main": "lib/index.js",
   "repository": "git@github.com:smooth-code/loadable-components.git",
   "author": "Greg Bergé <berge.greg@gmail.com>",

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -1,13 +1,10 @@
 {
-  "name": "@loadable/babel-plugin",
+  "name": "@parkwhiz-js/loadable-babel-plugin",
   "description": "Babel plugin for loadable (required for SSR).",
   "version": "5.10.0",
   "main": "lib/index.js",
   "repository": "git@github.com:smooth-code/loadable-components.git",
   "author": "Greg Bergé <berge.greg@gmail.com>",
-  "publishConfig": {
-    "access": "public"
-  },
   "keywords": [
     "loadable"
   ],

--- a/packages/component/CHANGELOG.md
+++ b/packages/component/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.10.3](https://github.com/smooth-code/loadable-components/compare/v5.10.2...v5.10.3) (2019-09-10)
+
+
+### Bug Fixes
+
+* support IE 11 without polyfill ([#416](https://github.com/smooth-code/loadable-components/issues/416)) ([80ee809](https://github.com/smooth-code/loadable-components/commit/80ee809)), closes [#397](https://github.com/smooth-code/loadable-components/issues/397)
+
+
+
+
+
 ## [5.10.2](https://github.com/smooth-code/loadable-components/compare/v5.10.1...v5.10.2) (2019-07-15)
 
 

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parkwhiz-js/loadable-component",
   "description": "React code splitting made easy.",
-  "version": "5.10.2",
+  "version": "5.10.3",
   "main": "dist/loadable.cjs.js",
   "module": "dist/loadable.esm.js",
   "repository": "git@github.com:smooth-code/loadable-components.git",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,14 +1,11 @@
 {
-  "name": "@loadable/component",
+  "name": "@parkwhiz-js/loadable-component",
   "description": "React code splitting made easy.",
   "version": "5.10.2",
   "main": "dist/loadable.cjs.js",
   "module": "dist/loadable.esm.js",
   "repository": "git@github.com:smooth-code/loadable-components.git",
   "author": "Greg Bergé <berge.greg@gmail.com>",
-  "publishConfig": {
-    "access": "public"
-  },
   "keywords": [
     "react",
     "ssr",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.10.3](https://github.com/smooth-code/loadable-components/compare/v5.10.2...v5.10.3) (2019-09-10)
+
+**Note:** Version bump only for package @parkwhiz-js/loadable-server
+
+
+
+
+
 ## [5.10.2](https://github.com/smooth-code/loadable-components/compare/v5.10.1...v5.10.2) (2019-07-15)
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parkwhiz-js/loadable-server",
   "description": "Server utilities for loadable.",
-  "version": "5.10.3",
+  "version": "5.10.4",
   "main": "lib/index.js",
   "repository": "git@github.com:smooth-code/loadable-components.git",
   "author": "Greg Bergé <berge.greg@gmail.com>",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,13 +1,10 @@
 {
-  "name": "@loadable/server",
+  "name": "@parkwhiz-js/loadable-server",
   "description": "Server utilities for loadable.",
   "version": "5.10.2",
   "main": "lib/index.js",
   "repository": "git@github.com:smooth-code/loadable-components.git",
   "author": "Greg Bergé <berge.greg@gmail.com>",
-  "publishConfig": {
-    "access": "public"
-  },
   "keywords": [
     "loadable"
   ],

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parkwhiz-js/loadable-server",
   "description": "Server utilities for loadable.",
-  "version": "5.10.2",
+  "version": "5.10.3",
   "main": "lib/index.js",
   "repository": "git@github.com:smooth-code/loadable-components.git",
   "author": "Greg Bergé <berge.greg@gmail.com>",

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -33,22 +33,39 @@ function extraPropsToString(asset, extraProps) {
   )
 }
 
+function getIntegrityProps(asset) {
+  return asset.integrity ? `integrity="${asset.integrity}" crossorigin="anonymous"` : ""
+}
+
 function assetToScriptTag(asset, extraProps) {
-  return `<script async data-chunk="${asset.chunk}" src="${
-    asset.url
-  }"${extraPropsToString(asset, extraProps)}></script>`
+  return (
+    `<script
+      async
+      data-chunk="${asset.chunk}"
+      src="${asset.url}"
+      ${getIntegrityProps(asset)}
+      ${extraPropsToString(asset, extraProps)}>
+    </script>`)
 }
 
 function assetToScriptElement(asset, extraProps) {
-  return (
-    <script
+  return asset.integrity
+    ? <script
+      key={asset.url}
+      async
+      data-chunk={asset.chunk}
+      src={asset.url}
+      integrity={asset.integrity}
+      crossOrigin="anonymous"
+      {...handleExtraProps(asset, extraProps)}
+    />
+    : <script
       key={asset.url}
       async
       data-chunk={asset.chunk}
       src={asset.url}
       {...handleExtraProps(asset, extraProps)}
     />
-  )
 }
 
 function assetToStyleString(asset, { inputFileSystem }) {
@@ -184,6 +201,11 @@ class ChunkExtractor {
     return chunkGroup
   }
 
+  getAssetIntegrity(fileName) {
+    const fileAsset = this.stats.assets.find(asset => asset.name === fileName);
+    return fileAsset ? fileAsset.integrity : undefined
+  }
+
   createChunkAsset({ filename, chunk, type, linkType }) {
     return {
       filename,
@@ -198,6 +220,7 @@ class ChunkExtractor {
       path: path.join(this.outputPath, filename),
       type,
       linkType,
+      integrity: this.getAssetIntegrity(filename),
     }
   }
 

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -34,18 +34,12 @@ function extraPropsToString(asset, extraProps) {
 }
 
 function getIntegrityProps(asset) {
-  return asset.integrity ? `integrity="${asset.integrity}" crossorigin="anonymous"` : ""
+  return asset.integrity ? ` integrity="${asset.integrity}" crossorigin="anonymous"` : ""
 }
 
 function assetToScriptTag(asset, extraProps) {
-  return (
-    `<script
-      async
-      data-chunk="${asset.chunk}"
-      src="${asset.url}"
-      ${getIntegrityProps(asset)}
-      ${extraPropsToString(asset, extraProps)}>
-    </script>`)
+  return (`<script async data-chunk="${asset.chunk}" src="${asset.url}"${getIntegrityProps(asset)}${
+    extraPropsToString(asset, extraProps)}></script>`)
 }
 
 function assetToScriptElement(asset, extraProps) {

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -174,6 +174,7 @@ class ChunkExtractor {
     outputPath,
     publicPath,
     inputFileSystem = fs,
+    integrityEnabled = false,
   } = {}) {
     this.namespace = namespace
     this.stats = stats || smartRequire(statsFile)
@@ -183,6 +184,7 @@ class ChunkExtractor {
     this.entrypoints = Array.isArray(entrypoints) ? entrypoints : [entrypoints]
     this.chunks = []
     this.inputFileSystem = inputFileSystem
+    this.integrityEnabled = integrityEnabled
   }
 
   resolvePublicUrl(filename) {
@@ -214,7 +216,7 @@ class ChunkExtractor {
       path: path.join(this.outputPath, filename),
       type,
       linkType,
-      integrity: this.getAssetIntegrity(filename),
+      integrity: this.integrityEnabled ? this.getAssetIntegrity(filename) : undefined,
     }
   }
 

--- a/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/webpack-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.10.3](https://github.com/smooth-code/loadable-components/compare/v5.10.2...v5.10.3) (2019-09-10)
+
+**Note:** Version bump only for package @parkwhiz-js/loadable-webpack-plugin
+
+
+
+
+
 ## [5.7.1](https://github.com/smooth-code/loadable-components/compare/v5.7.0...v5.7.1) (2019-03-19)
 
 

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parkwhiz-js/loadable-webpack-plugin",
   "description": "Webpack plugin for loadable (required for SSR).",
-  "version": "5.7.1",
+  "version": "5.10.3",
   "main": "lib/index.js",
   "repository": "git@github.com:smooth-code/loadable-components.git",
   "author": "Greg Bergé <berge.greg@gmail.com>",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,13 +1,10 @@
 {
-  "name": "@loadable/webpack-plugin",
+  "name": "@parkwhiz-js/loadable-webpack-plugin",
   "description": "Webpack plugin for loadable (required for SSR).",
   "version": "5.7.1",
   "main": "lib/index.js",
   "repository": "git@github.com:smooth-code/loadable-components.git",
   "author": "Greg Bergé <berge.greg@gmail.com>",
-  "publishConfig": {
-    "access": "public"
-  },
   "keywords": [
     "loadable"
   ],

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -21,7 +21,8 @@
     "prepublishOnly": "yarn run build"
   },
   "peerDependencies": {
-    "webpack": ">=4.6.0"
+    "webpack": ">=4.6.0",
+    "webpack-subresource-integrity": "^1.3.3"
   },
   "dependencies": {
     "mkdirp": "^0.5.1"


### PR DESCRIPTION
Add SRI capabilities for script chunks generated by webpack.


Future enhancements before bringing this to the parent repo would be
- Surround the added require in a try/catch to tell devs the library is required. All peerDependencies are optional and not everyone would use this functionality, so everyone should not be required to install it.
- Add option for integrity specific stuff such as `hashNames` and `crossorigin`
  - The crossorigin gets set on the output within the webpack.config file, so maybe we can find that setting within the compiler instead of requiring the dev to set it twice
- Find a way to only add the integrity if the resource is external
  - check the url is its a url or a path maybe?
